### PR TITLE
fix(typo): NOTIFICATION_TYPE

### DIFF
--- a/rootfs/container/functions/20-restic
+++ b/rootfs/container/functions/20-restic
@@ -860,7 +860,7 @@ EOF
     # $4 body
 
     if var_true "${ENABLE_NOTIFICATIONS}" ; then
-        notification_types=$(echo "${NOTIIFICATION_TYPE}" | tr "," "\n")
+        notification_types=$(echo "${NOTIFICATION_TYPE}" | tr "," "\n")
         for notification_type in $notification_types ; do
             case "${notification_type,,}" in
                 "custom" )


### PR DESCRIPTION
NOTIIFICATION_TYPE had a double-I typo, causing the variable to always read as empty, no notifications ever fired regardless of config. Users following the README (NOTIFICATION_TYPE) would never get notifications working without discovering the mismatch in the source.